### PR TITLE
Subfolder of zip file has been removed

### DIFF
--- a/src/oscodepoint/__init__.py
+++ b/src/oscodepoint/__init__.py
@@ -104,7 +104,7 @@ class BaseCodePoint(object):
     `CodePointDir`, or just forget about the difference and use `open_codepoint()`.
     """
 
-    root = 'Code-Point Open/'
+    root = ''
     headers_name = 'Doc/Code-Point_Open_Column_Headers.csv'
     metadata_name = 'Doc/metadata.txt'
     codelist_name = 'Doc/Codelist.xls'


### PR DESCRIPTION
The 'Code-Point Open' subfolder no longer exists inside the zip, so the root var can be set to an empty string (or removed altogether).

The 'data_name_format' is correct in the Git repo, but incorrect (the 'CSV' subfolder is missing) when I download this using pip. Not sure why that is.

Otherwise, this is a very useful package - I was going to write something similar myself until, surprise surprise, I discovered someone had already taken care of it. Python is great like that :-)
